### PR TITLE
fix: Chromium cannot load due to unsupported xpath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mumk/sitemap.pretty",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mumk/sitemap.pretty",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@tailwindcss/cli": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mumk/sitemap.pretty",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A collection of stylesheets for sitemap.xml",
   "repository": {
     "type": "git",

--- a/src/basic.xsl
+++ b/src/basic.xsl
@@ -198,10 +198,4 @@
             </xsl:for-each> 
         </ul>
     </xsl:template>
-
-    <xsl:template match="sitemap:loc[contains(text(), $websiteUrl)]">
-        <div class="bg-red-300">
-            <xsl:apply-templates />
-        </div>
-    </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Remove unused and unsupported xpath constructs for Chromium-based browsers.

Before: Unable to load sitemap with `basic.xsl` in Chromium-based browsers, but it works on Firefox.
After: It works for both Chromium-based browsers and Firefox.